### PR TITLE
fix: :sparkles: be explicit about auth basepath

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -13,6 +13,8 @@ export const { handle } = SvelteKitAuth({
       clientSecret: AUTH_GOOGLE_SECRET,
     }),
   ],
+  basePath: "/auth",
+  trustHost: true,
   secret: AUTH_SECRET,
   session: {
     strategy: "jwt",


### PR DESCRIPTION
Does what it says on the tin - bit of a wip