### PR TITLE
fix: restrict dashboard data to user's allowed regions

### DIFF
--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -330,11 +330,18 @@ export async function getAllRegionsAndDistricts(
   fetchFn?: typeof fetch,
 ): Promise<RegionAndDistrict[]> {
   if (allRegionsAndDistrictsCache) return allRegionsAndDistrictsCache;
-  // If fetchMonthlyData uses fetch, pass fetchFn if provided
-  const rows =
-    fetchFn && fetchMonthlyData.length > 0
-      ? await fetchMonthlyData(fetchFn)
-      : await fetchMonthlyData();
+  // Use the unfiltered reference list so the full geography is available
+  // regardless of the caller's allowed regions (and safe to cache globally).
+  const _fetch = fetchFn || fetch;
+  const response = await _fetch("/api/monthly-tz?scope=all");
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const payload = await response.json();
+  if (!payload.success) {
+    throw new Error(payload.error || "Failed to fetch reference data");
+  }
+  const rows = payload.data;
   const seen = new Set<string>();
   const result: RegionAndDistrict[] = [];
   for (const row of rows) {

--- a/src/routes/api/monthly-tz/+server.ts
+++ b/src/routes/api/monthly-tz/+server.ts
@@ -1,5 +1,6 @@
 import { json, type RequestHandler } from "@sveltejs/kit";
 import { Client } from "pg";
+import { getUserAllowedRegions } from "$lib/server/pmp";
 import {
   DB_HOST,
   DB_PORT,
@@ -22,10 +23,19 @@ const dbConfig = {
   idleTimeoutMillis: 30000,
 };
 
-export const GET: RequestHandler = async () => {
+export const GET: RequestHandler = async ({ locals, fetch }) => {
   let client: Client | null = null;
 
   try {
+    // Only authenticated users; restrict rows to the user's PMP-allowed regions.
+    const session = await locals.auth();
+    if (!session?.user?.email) {
+      return json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const allowedRegions = await getUserAllowedRegions(session.user.email, fetch);
+    const allowedRegionIDs = allowedRegions.map((r) => r.id);
+    const hasRegionFilter = allowedRegionIDs.length > 0; // empty = all regions
+
     // Create PostgreSQL client and connect
     client = new Client(dbConfig);
     await client.connect();
@@ -45,10 +55,13 @@ export const GET: RequestHandler = async () => {
         report_full_date,
         "tally-report_month" as tally_report_month
       FROM monthly_tz 
+      ${hasRegionFilter ? "WHERE tangis_region_id = ANY($1)" : ""}
       ORDER BY "SubmissionDate" DESC, region_name, district_council_name, facility_name
     `;
 
-    const result = await client.query(query);
+    const result = hasRegionFilter
+      ? await client.query(query, [allowedRegionIDs])
+      : await client.query(query);
 
     // Transform database results to match CSV structure
     const parsedData = result.rows.map((row) => ({

--- a/src/routes/api/monthly-tz/+server.ts
+++ b/src/routes/api/monthly-tz/+server.ts
@@ -23,7 +23,7 @@ const dbConfig = {
   idleTimeoutMillis: 30000,
 };
 
-export const GET: RequestHandler = async ({ locals, fetch }) => {
+export const GET: RequestHandler = async ({ locals, fetch, url }) => {
   let client: Client | null = null;
 
   try {
@@ -32,6 +32,31 @@ export const GET: RequestHandler = async ({ locals, fetch }) => {
     if (!session?.user?.email) {
       return json({ error: "Unauthorized" }, { status: 401 });
     }
+
+    // Reference mode: complete region/district list (names/IDs only, no tally
+    // data), unaffected by the per-user region filter. Used to build the full
+    // geography lookup; safe to expose as it carries no sensitive figures.
+    if (url.searchParams.get("scope") === "all") {
+      client = new Client(dbConfig);
+      await client.connect();
+      const refResult = await client.query(`
+        SELECT DISTINCT
+          region_name,
+          tangis_region_id,
+          district_council_name,
+          tangis_district_council_id
+        FROM monthly_tz
+        ORDER BY region_name, district_council_name
+      `);
+      const refData = refResult.rows.map((row) => ({
+        region_name: row.region_name || "",
+        tangis_region_id: row.tangis_region_id || "",
+        district_council_name: row.district_council_name || "",
+        tangis_district_council_id: row.tangis_district_council_id || "",
+      }));
+      return json({ success: true, data: refData, count: refData.length });
+    }
+
     const allowedRegions = await getUserAllowedRegions(session.user.email, fetch);
     const allowedRegionIDs = allowedRegions.map((r) => r.id);
     const hasRegionFilter = allowedRegionIDs.length > 0; // empty = all regions


### PR DESCRIPTION
## Summary

The `/api/monthly-tz` endpoint returned **all regions to every user**, so the map, bar chart, completeness table and detailed-data view ignored a user's PMP region whitelist. Only the export path (`/api/export-data`) enforced the restriction, so a user set to e.g. Arusha could still see all-Tanzania data on screen.

This branch makes the dashboard data path respect the same PMP allowed-regions whitelist the export path already uses.

## Changes

- **`ca6c0fb` — restrict monthly-tz data to user's allowed regions**
  - Require authentication on `/api/monthly-tz` (returns 401 otherwise).
  - Filter rows by the user's PMP-allowed regions via a parameterized `WHERE tangis_region_id = ANY($1)`.
  - Empty allowed list still means all regions (admins), matching the export/user-regions convention.

- **`7b81418` — keep region/district reference list complete under region filtering**
  - Filtering `monthly-tz` also scoped the cached region/district lookup the export modal builds from, so switching a user's region left the modal stale/empty.
  - Add a `?scope=all` reference branch to `/api/monthly-tz` returning the full region/district list (names/IDs only — no tally data, no region filter), still auth-gated.
  - Point `getAllRegionsAndDistricts` at it so the geography reference stays complete and globally cacheable.

## Test plan

- [ ] Set a user to a single region in PMP (e.g. Arusha) → dashboard map/chart/completeness/detailed-data show only that region.
- [ ] Export CSV → still only that region (unchanged).
- [ ] Change the user's region in PMP (e.g. to Morogoro) → dashboard **and** export modal both reflect Morogoro.
- [ ] Admin / empty region list → all regions visible.
- [ ] Unauthenticated request to `/api/monthly-tz` → 401.