### PR TITLE
fix: filter completeness and detailed-data tables by user's allowed regions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: lint, check and build
+name: lint, check, test and build
 
 on:
   pull_request:
@@ -58,9 +58,27 @@ jobs:
       - name: run checks
         run: npm run check
 
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v5
+
+      - name: setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: install dependencies
+        run: npm clean-install
+
+      - name: run tests
+        run: npm test
+
   build:
     runs-on: ubuntu-latest
-    needs: [lint, check]
+    needs: [lint, check, test]
     # Only run this job on pull requests
     if: github.event_name == 'pull_request'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "svelte-check": "^4.3.1",
         "typescript": "~5.9.2",
         "typescript-eslint": "^8.43.0",
-        "vite": "^6.4.1"
+        "vite": "^6.4.1",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@auth/core": {
@@ -1748,9 +1749,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@steeze-ui/heroicons": {
@@ -2234,6 +2235,17 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -2523,6 +2535,13 @@
         "@types/d3-interpolate": "*",
         "@types/d3-selection": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -2838,6 +2857,119 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2985,6 +3117,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -3046,6 +3188,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3361,6 +3513,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -4144,6 +4303,13 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
@@ -4457,6 +4623,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4509,6 +4685,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-content-type-parse": {
@@ -4594,10 +4780,13 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5782,9 +5971,9 @@
       "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -8846,6 +9035,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -9090,6 +9290,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pg": {
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
@@ -9178,9 +9385,10 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -10048,6 +10256,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10276,6 +10491,20 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
@@ -10664,20 +10893,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.3.tgz",
+      "integrity": "sha512-g62dB+w1/OEFnPvmX0yd/HnetYITOL+1nJW7kitOycOeAvmbWC/nu0fwmmQ/kupNojqExzyC/T++pST/jRJ2mQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -10997,6 +11253,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11010,6 +11356,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -11073,20 +11436,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "svelte-kit sync && vitest run",
+    "test:watch": "svelte-kit sync && vitest"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
@@ -34,7 +36,8 @@
     "svelte-check": "^4.3.1",
     "typescript": "~5.9.2",
     "typescript-eslint": "^8.43.0",
-    "vite": "^6.4.1"
+    "vite": "^6.4.1",
+    "vitest": "^4.1.7"
   },
   "dependencies": {
     "@auth/sveltekit": "^1.10.0",

--- a/src/lib/components/tables/completeness-table.svelte
+++ b/src/lib/components/tables/completeness-table.svelte
@@ -11,6 +11,55 @@
   let error: string | null = null;
   let expandedItems = new Set<string>();
 
+  // -------------------------------------------------------------------------
+  // Region whitelist (loaded once on mount from /api/user-regions).
+  //
+  //   - `null`            → no restriction (admin / unrestricted user).
+  //   - empty array `[]`  → user is whitelisted to ZERO regions.
+  //   - non-empty array   → only those region IDs are visible in the table.
+  //
+  // We pass this value into getCompletenessData() so the same data shaping
+  // function can be reused unchanged for both restricted and admin users.
+  // -------------------------------------------------------------------------
+  let allowedRegionIDs: string[] | null = [];
+
+  // Shape of the JSON returned by /api/user-regions.
+  type UserRegionsResponse = {
+    regions: { regionID: string; regionName: string }[];
+    isAllRegions: boolean;
+  };
+
+  async function loadAllowedRegions() {
+    let response: Response;
+    try {
+      response = await fetch("/api/user-regions");
+    } catch (err) {
+      console.error("[completeness] network error fetching user-regions:", err);
+      allowedRegionIDs = [];
+      return;
+    }
+
+    if (!response.ok) {
+      console.error(
+        "[completeness] /api/user-regions returned HTTP",
+        response.status,
+      );
+      allowedRegionIDs = [];
+      return;
+    }
+
+    const json = (await response.json()) as UserRegionsResponse;
+
+    if (json.isAllRegions) {
+      // Admin / unrestricted user → no whitelist filtering.
+      allowedRegionIDs = null;
+      return;
+    }
+
+    // Build a plain array of region IDs from the response.
+    allowedRegionIDs = json.regions.map((r) => r.regionID);
+  }
+
   // Get last 12 months for column headers
   let monthColumns: { display: string; key: string }[] = [];
 
@@ -120,8 +169,12 @@
       isLoading = true;
       error = null;
 
-      // Fetch completeness data
-      data = await getCompletenessData($selectedRegionID, $selectedDistrictID);
+      // Fetch completeness data, restricted to the user's allowed regions.
+      data = await getCompletenessData(
+        $selectedRegionID,
+        $selectedDistrictID,
+        allowedRegionIDs,
+      );
     } catch (err) {
       console.error("Error loading completeness data:", err);
       error = err instanceof Error ? err.message : "Unknown error";
@@ -133,11 +186,17 @@
   let unsubscribeRegion: (() => void) | undefined;
   let unsubscribeDistrict: (() => void) | undefined;
 
-  onMount(() => {
+  onMount(async () => {
     generateMonthColumns();
+
+    // Load the user's allowed regions FIRST so the very first call to
+    // loadCompletenessData already has the correct whitelist.
+    await loadAllowedRegions();
+
     loadCompletenessData();
 
-    // Subscribe to store changes
+    // Subscribe to store changes so the table refreshes when the user picks
+    // a different region/district in the header search.
     unsubscribeRegion = selectedRegionID.subscribe(() => {
       loadCompletenessData();
     });

--- a/src/lib/components/tables/completeness-table.svelte
+++ b/src/lib/components/tables/completeness-table.svelte
@@ -48,11 +48,34 @@
       return;
     }
 
-    const json = (await response.json()) as UserRegionsResponse;
+    // Parse the JSON body in its own try block: response.json() can throw on
+    // malformed payloads. Failing here must also fail-closed so the component
+    // does not get stuck in a perpetual loading state.
+    let json: UserRegionsResponse;
+    try {
+      json = (await response.json()) as UserRegionsResponse;
+    } catch (err) {
+      console.error(
+        "[completeness] /api/user-regions response parse error:",
+        err,
+      );
+      allowedRegionIDs = [];
+      return;
+    }
 
     if (json.isAllRegions) {
       // Admin / unrestricted user → no whitelist filtering.
       allowedRegionIDs = null;
+      return;
+    }
+
+    // Defensive shape check: if the payload is missing the regions array,
+    // fail-closed rather than letting .map() throw a TypeError.
+    if (!Array.isArray(json.regions)) {
+      console.error(
+        "[completeness] /api/user-regions response missing regions[]",
+      );
+      allowedRegionIDs = [];
       return;
     }
 

--- a/src/lib/components/tables/completeness-table.svelte
+++ b/src/lib/components/tables/completeness-table.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { getCompletenessData, type CompletenessData } from "$lib/data/api";
   import { selectedDistrictID, selectedRegionID } from "$lib/stores/uiStore";
+  import {
+    allowedRegionIDs,
+    loadAllowedRegions,
+  } from "$lib/stores/userRegions";
   import { onMount, onDestroy } from "svelte";
   import { ChevronDown, ChevronRight } from "@steeze-ui/heroicons";
   import { Icon } from "@steeze-ui/svelte-icon";
@@ -10,78 +14,6 @@
   let isLoading = true;
   let error: string | null = null;
   let expandedItems = new Set<string>();
-
-  // -------------------------------------------------------------------------
-  // Region whitelist (loaded once on mount from /api/user-regions).
-  //
-  //   - `null`            → no restriction (admin / unrestricted user).
-  //   - empty array `[]`  → user is whitelisted to ZERO regions.
-  //   - non-empty array   → only those region IDs are visible in the table.
-  //
-  // We pass this value into getCompletenessData() so the same data shaping
-  // function can be reused unchanged for both restricted and admin users.
-  // -------------------------------------------------------------------------
-  let allowedRegionIDs: string[] | null = [];
-
-  // Shape of the JSON returned by /api/user-regions.
-  type UserRegionsResponse = {
-    regions: { regionID: string; regionName: string }[];
-    isAllRegions: boolean;
-  };
-
-  async function loadAllowedRegions() {
-    let response: Response;
-    try {
-      response = await fetch("/api/user-regions");
-    } catch (err) {
-      console.error("[completeness] network error fetching user-regions:", err);
-      allowedRegionIDs = [];
-      return;
-    }
-
-    if (!response.ok) {
-      console.error(
-        "[completeness] /api/user-regions returned HTTP",
-        response.status,
-      );
-      allowedRegionIDs = [];
-      return;
-    }
-
-    // Parse the JSON body in its own try block: response.json() can throw on
-    // malformed payloads. Failing here must also fail-closed so the component
-    // does not get stuck in a perpetual loading state.
-    let json: UserRegionsResponse;
-    try {
-      json = (await response.json()) as UserRegionsResponse;
-    } catch (err) {
-      console.error(
-        "[completeness] /api/user-regions response parse error:",
-        err,
-      );
-      allowedRegionIDs = [];
-      return;
-    }
-
-    if (json.isAllRegions) {
-      // Admin / unrestricted user → no whitelist filtering.
-      allowedRegionIDs = null;
-      return;
-    }
-
-    // Defensive shape check: if the payload is missing the regions array,
-    // fail-closed rather than letting .map() throw a TypeError.
-    if (!Array.isArray(json.regions)) {
-      console.error(
-        "[completeness] /api/user-regions response missing regions[]",
-      );
-      allowedRegionIDs = [];
-      return;
-    }
-
-    // Build a plain array of region IDs from the response.
-    allowedRegionIDs = json.regions.map((r) => r.regionID);
-  }
 
   // Get last 12 months for column headers
   let monthColumns: { display: string; key: string }[] = [];
@@ -196,7 +128,7 @@
       data = await getCompletenessData(
         $selectedRegionID,
         $selectedDistrictID,
-        allowedRegionIDs,
+        $allowedRegionIDs,
       );
     } catch (err) {
       console.error("Error loading completeness data:", err);

--- a/src/lib/components/tables/health-facilities-table.svelte
+++ b/src/lib/components/tables/health-facilities-table.svelte
@@ -156,7 +156,15 @@
 
   let expandedState: ExpandedState = {};
 
+  // Guards against out-of-order async runs. This reactive block re-runs on
+  // every dependency change (selected region/district, allowed regions) and
+  // each run awaits network calls. Each run takes the next sequence number;
+  // only the latest run is allowed to commit its result, so a slow earlier
+  // run can't overwrite data computed for a newer selection.
+  let loadSeq = 0;
+
   $: (async () => {
+    const seq = ++loadSeq;
     // Always fetch all facilities for the selected region (not just the district)
     const facilities = await getFacilitiesByRegionDistrict(
       $selectedRegionID,
@@ -167,6 +175,9 @@
     for (const id of facilities) {
       dataWithNulls.push(await getFacilityInfoById(id));
     }
+    // No awaits beyond this point: bail if a newer run started while we were
+    // awaiting, so the rest (data + expandedState) commits atomically.
+    if (seq !== loadSeq) return;
     let collapsed = collapseFacilityInfo(
       dataWithNulls.filter((facility) => facility !== null),
     );

--- a/src/lib/components/tables/health-facilities-table.svelte
+++ b/src/lib/components/tables/health-facilities-table.svelte
@@ -5,6 +5,7 @@
     type FacilityInfo,
   } from "$lib/data/api";
   import { selectedRegionID, selectedDistrictID } from "$lib/stores/uiStore";
+  import { onMount } from "svelte";
   import {
     createColumnHelper,
     createSvelteTable,
@@ -114,6 +115,34 @@
     return result;
   }
 
+  // The user's PMP-allowed region IDs. Starts as [] (show nothing) until loaded.
+  // null means no restriction (admin). [] means restricted to zero regions.
+  let allowedRegionIDs: string[] | null = [];
+
+  async function loadAllowedRegions() {
+    try {
+      const response = await fetch("/api/user-regions");
+      if (!response.ok) {
+        allowedRegionIDs = [];
+        return;
+      }
+      const json = await response.json();
+      if (json.isAllRegions) {
+        allowedRegionIDs = null;
+      } else {
+        allowedRegionIDs = Array.isArray(json.regions)
+          ? json.regions.map((r: { regionID: string }) => r.regionID)
+          : [];
+      }
+    } catch {
+      allowedRegionIDs = [];
+    }
+  }
+
+  onMount(async () => {
+    await loadAllowedRegions();
+  });
+
   let data: FacilityInfoWithChildren[] = [];
 
   const columnHelper = createColumnHelper<FacilityInfoWithChildren>();
@@ -152,6 +181,7 @@
     const facilities = await getFacilitiesByRegionDistrict(
       $selectedRegionID,
       null,
+      allowedRegionIDs,
     );
     const dataWithNulls: Array<FacilityInfo | null> = [];
     for (const id of facilities) {

--- a/src/lib/components/tables/health-facilities-table.svelte
+++ b/src/lib/components/tables/health-facilities-table.svelte
@@ -5,6 +5,10 @@
     type FacilityInfo,
   } from "$lib/data/api";
   import { selectedRegionID, selectedDistrictID } from "$lib/stores/uiStore";
+  import {
+    allowedRegionIDs,
+    loadAllowedRegions,
+  } from "$lib/stores/userRegions";
   import { onMount } from "svelte";
   import {
     createColumnHelper,
@@ -115,30 +119,6 @@
     return result;
   }
 
-  // The user's PMP-allowed region IDs. Starts as [] (show nothing) until loaded.
-  // null means no restriction (admin). [] means restricted to zero regions.
-  let allowedRegionIDs: string[] | null = [];
-
-  async function loadAllowedRegions() {
-    try {
-      const response = await fetch("/api/user-regions");
-      if (!response.ok) {
-        allowedRegionIDs = [];
-        return;
-      }
-      const json = await response.json();
-      if (json.isAllRegions) {
-        allowedRegionIDs = null;
-      } else {
-        allowedRegionIDs = Array.isArray(json.regions)
-          ? json.regions.map((r: { regionID: string }) => r.regionID)
-          : [];
-      }
-    } catch {
-      allowedRegionIDs = [];
-    }
-  }
-
   onMount(async () => {
     await loadAllowedRegions();
   });
@@ -181,7 +161,7 @@
     const facilities = await getFacilitiesByRegionDistrict(
       $selectedRegionID,
       null,
-      allowedRegionIDs,
+      $allowedRegionIDs,
     );
     const dataWithNulls: Array<FacilityInfo | null> = [];
     for (const id of facilities) {

--- a/src/lib/data/api.test.ts
+++ b/src/lib/data/api.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the data layer so we control the rows without hitting /api/monthly-tz.
+vi.mock("$data/liveDB", () => ({
+  fetchMonthlyData: vi.fn(),
+}));
+
+import { getCompletenessData, getFacilitiesByRegionDistrict } from "./api";
+import { fetchMonthlyData } from "$data/liveDB";
+
+const rows = vi.mocked(fetchMonthlyData);
+
+// Two regions, one facility each.
+const ROWS = [
+  {
+    tangis_facility_id: "f-mt",
+    region_name: "Mtwara",
+    tangis_region_id: "R-MT",
+    district_council_name: "Mtwara DC",
+    tangis_district_council_id: "D-MT",
+    facility_name: "Mtwara HC",
+    tally_total_patients: "5",
+    tally_total_vials: "3",
+    submission_date: "",
+    report_full_date: "",
+    tally_report_month: "Apr (4/2025)",
+  },
+  {
+    tangis_facility_id: "f-mr",
+    region_name: "Morogoro",
+    tangis_region_id: "R-MR",
+    district_council_name: "Morogoro DC",
+    tangis_district_council_id: "D-MR",
+    facility_name: "Morogoro HC",
+    tally_total_patients: "2",
+    tally_total_vials: "1",
+    submission_date: "",
+    report_full_date: "",
+    tally_report_month: "Apr (4/2025)",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rows.mockResolvedValue(ROWS as any);
+});
+
+// Regression: the detailed-data table previously showed every region. It must
+// now be restricted to the user's allowed regions.
+describe("getFacilitiesByRegionDistrict — region whitelist", () => {
+  it("returns only facilities in the allowed regions", async () => {
+    const ids = await getFacilitiesByRegionDistrict(null, null, ["R-MT"]);
+    expect(ids).toEqual(["f-mt"]);
+  });
+
+  it("returns all facilities when allowedRegionIDs is null (admin)", async () => {
+    const ids = await getFacilitiesByRegionDistrict(null, null, null);
+    expect(ids.sort()).toEqual(["f-mr", "f-mt"]);
+  });
+
+  it("returns nothing when the allowed list is empty", async () => {
+    const ids = await getFacilitiesByRegionDistrict(null, null, []);
+    expect(ids).toEqual([]);
+  });
+});
+
+// Regression: the completeness table previously showed every region. It must
+// now be restricted to the user's allowed regions.
+describe("getCompletenessData — region whitelist", () => {
+  const regionNames = (data: { regionName: string | null }[]) =>
+    data.map((d) => d.regionName).sort();
+
+  it("includes only the allowed regions", async () => {
+    const data = await getCompletenessData(null, null, ["R-MT"]);
+    expect(regionNames(data)).toEqual(["Mtwara"]);
+  });
+
+  it("includes all regions when allowedRegionIDs is null (admin)", async () => {
+    const data = await getCompletenessData(null, null, null);
+    expect(regionNames(data)).toEqual(["Morogoro", "Mtwara"]);
+  });
+
+  it("includes nothing when the allowed list is empty", async () => {
+    const data = await getCompletenessData(null, null, []);
+    expect(data).toEqual([]);
+  });
+});

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -392,6 +392,12 @@ export async function getCompletenessData(
     }
   }
 
+  // Precompute a Set for O(1) lookups inside the per-row filter below
+  // (vs O(rows × allowedRegionIDs) with Array.includes).
+  // null → unrestricted; empty Set → no regions allowed.
+  const allowedRegionSet =
+    allowedRegionIDs !== null ? new Set(allowedRegionIDs) : null;
+
   // Keep only rows that match every active filter. Each condition is on its
   // own line so it's obvious which filter is doing what.
   const filteredRows = rows.filter((row: MonthlyDataRow) => {
@@ -404,12 +410,11 @@ export async function getCompletenessData(
       return false;
     }
     // PMP region filter.
-    // null means unrestricted. An empty array means no regions are allowed.
-    if (allowedRegionIDs !== null) {
-      const regionIsAllowed = allowedRegionIDs.includes(row.tangis_region_id);
-      if (!regionIsAllowed) {
-        return false;
-      }
+    if (
+      allowedRegionSet !== null &&
+      !allowedRegionSet.has(row.tangis_region_id)
+    ) {
+      return false;
     }
 
     return true;

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -400,10 +400,7 @@ export async function getCompletenessData(
       return false;
     }
     // District filter (when a specific district is selected in the UI).
-    if (
-      districtID !== null &&
-      row.tangis_district_council_id !== districtID
-    ) {
+    if (districtID !== null && row.tangis_district_council_id !== districtID) {
       return false;
     }
     // PMP region filter.

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -96,14 +96,21 @@ export async function getFacilityInfoById(
 export async function getFacilitiesByRegionDistrict(
   regionID: string | null,
   districtID: string | null,
+  allowedRegionIDs: string[] | null = null,
 ) {
   const rows = await fetchMonthlyData();
   // Filter for region and (optionally) district using IDs
-  const facilities = rows.filter(
-    (row: MonthlyDataRow) =>
-      (regionID == null || row.tangis_region_id === regionID) &&
-      (districtID == null || row.tangis_district_council_id === districtID),
-  );
+  const facilities = rows.filter((row: MonthlyDataRow) => {
+    if (regionID !== null && row.tangis_region_id !== regionID) return false;
+    if (districtID !== null && row.tangis_district_council_id !== districtID)
+      return false;
+    if (
+      allowedRegionIDs !== null &&
+      !allowedRegionIDs.includes(row.tangis_region_id)
+    )
+      return false;
+    return true;
+  });
   // Get unique tangis_facility_id only
   const uniqueIds = Array.from(
     new Set(facilities.map((row: MonthlyDataRow) => row.tangis_facility_id)),

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -361,6 +361,11 @@ export async function getAllRegionsAndDistricts(
 export async function getCompletenessData(
   regionID: string | null = null,
   districtID: string | null = null,
+  // The user's PMP-allowed region IDs.
+  //   - `null`          → no restriction (admin / unrestricted user).
+  //   - empty array     → the user can see no regions.
+  //   - non-empty array → the user can see only those regions.
+  allowedRegionIDs: string[] | null = null,
 ): Promise<CompletenessData[]> {
   const rows = await fetchMonthlyData();
 
@@ -387,12 +392,31 @@ export async function getCompletenessData(
     }
   }
 
-  // Get all unique facilities that match the filter criteria
-  const filteredRows = rows.filter(
-    (row: MonthlyDataRow) =>
-      (regionID == null || row.tangis_region_id === regionID) &&
-      (districtID == null || row.tangis_district_council_id === districtID),
-  );
+  // Keep only rows that match every active filter. Each condition is on its
+  // own line so it's obvious which filter is doing what.
+  const filteredRows = rows.filter((row: MonthlyDataRow) => {
+    // Region filter (when a specific region is selected in the UI).
+    if (regionID !== null && row.tangis_region_id !== regionID) {
+      return false;
+    }
+    // District filter (when a specific district is selected in the UI).
+    if (
+      districtID !== null &&
+      row.tangis_district_council_id !== districtID
+    ) {
+      return false;
+    }
+    // PMP region filter.
+    // null means unrestricted. An empty array means no regions are allowed.
+    if (allowedRegionIDs !== null) {
+      const regionIsAllowed = allowedRegionIDs.includes(row.tangis_region_id);
+      if (!regionIsAllowed) {
+        return false;
+      }
+    }
+
+    return true;
+  });
 
   const facilityMap = new Map<
     string,

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -99,14 +99,18 @@ export async function getFacilitiesByRegionDistrict(
   allowedRegionIDs: string[] | null = null,
 ) {
   const rows = await fetchMonthlyData();
+  // Precompute a Set for O(1) whitelist lookups (consistent with
+  // getCompletenessData). null → unrestricted; empty Set → no regions allowed.
+  const allowedRegionSet =
+    allowedRegionIDs !== null ? new Set(allowedRegionIDs) : null;
   // Filter for region and (optionally) district using IDs
   const facilities = rows.filter((row: MonthlyDataRow) => {
     if (regionID !== null && row.tangis_region_id !== regionID) return false;
     if (districtID !== null && row.tangis_district_council_id !== districtID)
       return false;
     if (
-      allowedRegionIDs !== null &&
-      !allowedRegionIDs.includes(row.tangis_region_id)
+      allowedRegionSet !== null &&
+      !allowedRegionSet.has(row.tangis_region_id)
     )
       return false;
     return true;

--- a/src/lib/stores/userRegions.test.ts
+++ b/src/lib/stores/userRegions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { get } from "svelte/store";
+import { allowedRegionIDs, loadAllowedRegions } from "./userRegions";
+
+// Regression: the shared region-whitelist loader must fail CLOSED. A broken
+// /api/user-regions response (HTTP error, network error, malformed body) must
+// leave the store at [] (show nothing), never null (which means "all regions").
+// It must also dedupe concurrent callers into a single fetch.
+function res(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("userRegions store — loadAllowedRegions", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    allowedRegionIDs.set([]); // reset shared store between cases
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("maps regions to their IDs", async () => {
+    fetchMock.mockResolvedValue(
+      res({ isAllRegions: false, regions: [{ regionID: "R-MT" }] }),
+    );
+    await loadAllowedRegions();
+    expect(get(allowedRegionIDs)).toEqual(["R-MT"]);
+  });
+
+  it("sets null (no restriction) when isAllRegions is true", async () => {
+    fetchMock.mockResolvedValue(res({ isAllRegions: true, regions: [] }));
+    await loadAllowedRegions();
+    expect(get(allowedRegionIDs)).toBeNull();
+  });
+
+  it("fails closed ([]) on an HTTP error", async () => {
+    fetchMock.mockResolvedValue(res({}, false));
+    await loadAllowedRegions();
+    expect(get(allowedRegionIDs)).toEqual([]);
+  });
+
+  it("fails closed ([]) on a network error", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    await loadAllowedRegions();
+    expect(get(allowedRegionIDs)).toEqual([]);
+  });
+
+  it("fails closed ([]) when the regions array is missing", async () => {
+    fetchMock.mockResolvedValue(res({ isAllRegions: false }));
+    await loadAllowedRegions();
+    expect(get(allowedRegionIDs)).toEqual([]);
+  });
+
+  it("dedupes concurrent callers into a single fetch", async () => {
+    fetchMock.mockResolvedValue(
+      res({ isAllRegions: false, regions: [{ regionID: "R-MT" }] }),
+    );
+    await Promise.all([loadAllowedRegions(), loadAllowedRegions()]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/stores/userRegions.ts
+++ b/src/lib/stores/userRegions.ts
@@ -1,0 +1,66 @@
+import { writable } from "svelte/store";
+
+// The user's PMP-allowed region IDs.
+//   - `null`            → no restriction (admin / unrestricted user)
+//   - empty array `[]`  → user can see no regions (also the fail-closed default)
+//   - non-empty array   → user can see only these region IDs
+export const allowedRegionIDs = writable<string[] | null>([]);
+
+type UserRegionsResponse = {
+  regions: { regionID: string; regionName: string }[];
+  isAllRegions: boolean;
+};
+
+// Cache the in-flight (or completed) load promise rather than a boolean, so
+// concurrent callers all await the SAME fetch. A boolean guard would let a
+// second caller return before the first fetch resolved, reading the default
+// empty store and showing nothing.
+let loadPromise: Promise<void> | null = null;
+
+// Fetches the current user's allowed regions from /api/user-regions and writes
+// the result into the shared `allowedRegionIDs` store. Safe to call from
+// multiple components — only the first call hits the network; every caller
+// awaits the same fetch and therefore sees the resolved value.
+export function loadAllowedRegions(): Promise<void> {
+  if (!loadPromise) loadPromise = doLoadAllowedRegions();
+  return loadPromise;
+}
+
+async function doLoadAllowedRegions(): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch("/api/user-regions");
+  } catch (err) {
+    console.error("[userRegions] network error:", err);
+    allowedRegionIDs.set([]);
+    return;
+  }
+
+  if (!response.ok) {
+    console.error("[userRegions] HTTP error:", response.status);
+    allowedRegionIDs.set([]);
+    return;
+  }
+
+  let json: UserRegionsResponse;
+  try {
+    json = (await response.json()) as UserRegionsResponse;
+  } catch (err) {
+    console.error("[userRegions] parse error:", err);
+    allowedRegionIDs.set([]);
+    return;
+  }
+
+  if (json.isAllRegions) {
+    allowedRegionIDs.set(null);
+    return;
+  }
+
+  if (!Array.isArray(json.regions)) {
+    console.error("[userRegions] response missing regions[]");
+    allowedRegionIDs.set([]);
+    return;
+  }
+
+  allowedRegionIDs.set(json.regions.map((r) => r.regionID));
+}

--- a/src/lib/stores/userRegions.ts
+++ b/src/lib/stores/userRegions.ts
@@ -22,7 +22,15 @@ let loadPromise: Promise<void> | null = null;
 // multiple components — only the first call hits the network; every caller
 // awaits the same fetch and therefore sees the resolved value.
 export function loadAllowedRegions(): Promise<void> {
-  if (!loadPromise) loadPromise = doLoadAllowedRegions();
+  if (!loadPromise) {
+    // Clear the cached promise once it settles. Concurrent callers still share
+    // the single in-flight fetch, but a later mount (or a retry after a
+    // transient PMP failure) can fetch again instead of being stuck forever at
+    // the fail-closed default.
+    loadPromise = doLoadAllowedRegions().finally(() => {
+      loadPromise = null;
+    });
+  }
   return loadPromise;
 }
 

--- a/src/test/env-static-private.ts
+++ b/src/test/env-static-private.ts
@@ -1,0 +1,10 @@
+// Test-only stub for SvelteKit's `$env/static/private` virtual module.
+// Aliased in vitest.config.ts so server modules can be imported under test
+// without the real SvelteKit env machinery. Values are dummies — tests that
+// care about behaviour mock the modules that consume these.
+export const AUTH_SECRET = "test-secret";
+export const AUTH_GOOGLE_ID = "test-google-id";
+export const AUTH_GOOGLE_SECRET = "test-google-secret";
+export const PMP_BASE_URL = "http://pmp.test";
+export const PMP_USERNAME = "test-user";
+export const PMP_PASSWORD = "test-pass";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+// Minimal Vitest setup. Server-side unit tests run in the node environment.
+// Aliases mirror svelte.config.js (+ the SvelteKit `$env/static/private`
+// virtual module) so source modules can be imported under test without the
+// full SvelteKit/Vite plugin machinery:
+//   - $lib / $data / $components / $utils → real source under src/lib
+//   - $env/static/private                 → a test stub (real secrets unneeded)
+const r = (p: string) => fileURLToPath(new URL(p, import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      $lib: r("./src/lib"),
+      $data: r("./src/lib/data"),
+      $components: r("./src/lib/components"),
+      $utils: r("./src/lib/utils"),
+      "$env/static/private": r("./src/test/env-static-private.ts"),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.{test,spec}.ts"],
+  },
+});


### PR DESCRIPTION
## What this does

Some views now only show the regions a user is allowed to see (set in PMP). The big-picture views stay global.

- Map — still shows all regions
- Bar chart — still shows all regions
- Completeness table — now filtered
- Detailed-data table — now filtered
- Export — was already filtered

## How

- `getCompletenessData()` and `getFacilitiesByRegionDistrict()` now take an optional list of allowed region IDs and only return rows from those regions.
  - no list = show everything (admin)
  - empty list = show nothing
- The completeness and detailed-data table components ask `/api/user-regions` who the user is allowed to see, then pass that list in.
- If PMP can't be reached (network/HTTP/parse error), the tables show nothing instead of leaking all regions.

## Note

Replaces PR #96, which filtered too much (it also hid map + bar chart). #96 - already closed

## How to test

- One region in PMP → completeness + detailed-data show only that region; map, bar chart, export unchanged.
- Several regions → both tables show only those.
- Empty / admin → both tables show all regions.
- PMP offline → both tables show nothing.