### PR TITLE
fix: render desktop two-column layout on laptop (MacBook Pro 13) screens

### DIFF
--- a/src/lib/components/pages/map.svelte
+++ b/src/lib/components/pages/map.svelte
@@ -9,7 +9,7 @@
 
 <div id="map" class="page mx-5 flex flex-col lg:mx-10" style="height: 85vh;">
   <div
-    class="mb-8 grid min-h-0 flex-1 grid-cols-1 gap-6 2xl:grid-cols-2"
+    class="mb-8 grid min-h-0 flex-1 grid-cols-1 gap-6 lg:grid-cols-2"
     style="height: 100%;"
   >
     <!-- Map visualization -->


### PR DESCRIPTION
## What this fixes

Audrey's dashboard collapsed to a single-column ("mobile") layout on **MacBook Pro 13"** screens — the map and bar chart stacked vertically instead of sitting side-by-side.

Addresses **RabiesResearch/project_IBCM#258** (Audrey: incorrectly rendering in single-column / mobile mode on MacBook Pro 13). Parent: #252.

## Root cause

The map + chart grid only switched to two columns at Tailwind's `2xl` breakpoint (**1536px**):

```html
<div class="... grid grid-cols-1 gap-6 2xl:grid-cols-2">
```

A 13" MacBook Pro has an effective CSS viewport of ~**1280px** (1440px in "More Space" mode) — both below 1536 — so the two-column layout never activated and it rendered single-column. This is a pure CSS breakpoint issue; there is no JS/device detection involved.

## Change

`src/lib/components/pages/map.svelte` — lower the breakpoint from `2xl:grid-cols-2` to `lg:grid-cols-2` (1024px), so laptop-class screens get the full desktop layout.

## Verification

Reproduced and verified in Chrome devtools at 1280×800 (MBP 13" "Laptop with MDPI screen" preset):
- **Before:** map and chart stacked (single column).
- **After:** map and chart side-by-side (two columns); layout holds from 1024px upward, collapsing to single column only on genuinely narrow screens.