### PR TITLE
feat: vaccine-stock filter on completeness table (#255)

### DIFF
--- a/src/lib/components/tables/completeness-table.svelte
+++ b/src/lib/components/tables/completeness-table.svelte
@@ -15,6 +15,9 @@
   let error: string | null = null;
   let expandedItems = new Set<string>();
 
+  // Default ON: show only facilities PMP marks as holding vaccine stock.
+  let onlyWithVaccineStock = true;
+
   // Get last 12 months for column headers
   let monthColumns: { display: string; key: string }[] = [];
 
@@ -129,6 +132,7 @@
         $selectedRegionID,
         $selectedDistrictID,
         $allowedRegionIDs,
+        onlyWithVaccineStock,
       );
 
       // The selection drives which rows exist, so stale manual expansions
@@ -185,7 +189,19 @@
 </script>
 
 <div class="p-4">
-  <h2 class="mb-4 text-xl font-bold">Data Completeness</h2>
+  <div class="mb-4 flex flex-wrap items-center justify-between gap-2">
+    <h2 class="text-xl font-bold">Data Completeness</h2>
+
+    <label class="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+      <input
+        type="checkbox"
+        class="h-4 w-4 rounded border-gray-300"
+        bind:checked={onlyWithVaccineStock}
+        on:change={loadCompletenessData}
+      />
+      Only show facilities with vaccine stock
+    </label>
+  </div>
 
   {#if isLoading}
     <div class="flex justify-center p-8">
@@ -428,6 +444,13 @@
       </div>
     </div>
   {:else}
-    <div class="p-4 text-center text-gray-500">No completeness data found.</div>
+    <div class="p-4 text-center text-gray-500">
+      {#if onlyWithVaccineStock}
+        No facilities with vaccine stock found. Facilities are flagged in the
+        PMP portal, or untick the filter above to show all facilities.
+      {:else}
+        No completeness data found.
+      {/if}
+    </div>
   {/if}
 </div>

--- a/src/lib/data/api.test.ts
+++ b/src/lib/data/api.test.ts
@@ -121,3 +121,62 @@ describe("getCompletenessData — vaccine-stock filter", () => {
     expect(regionNames(data)).toEqual([]);
   });
 });
+
+// Accuracy: the completeness % must recompute over the FILTERED set, so the
+// same region can read differently with the toggle on vs off.
+describe("getCompletenessData — completeness recalculates with the filter", () => {
+  // One district, two facilities:
+  //  - f-stock:   has stock, REPORTED this month
+  //  - f-nostock: no stock,  did NOT report this month (only an old report)
+  const now = new Date();
+  const curMonth = `(${now.getMonth() + 1}/${now.getFullYear()})`;
+  const curKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+
+  const TWO_FAC = [
+    {
+      tangis_facility_id: "f-stock",
+      region_name: "Reg",
+      tangis_region_id: "R",
+      district_council_name: "Dist",
+      tangis_district_council_id: "D",
+      facility_name: "Stocked HC",
+      tally_total_patients: "1",
+      tally_total_vials: "1",
+      submission_date: "",
+      report_full_date: "",
+      tally_report_month: `Now ${curMonth}`,
+    },
+    {
+      tangis_facility_id: "f-nostock",
+      region_name: "Reg",
+      tangis_region_id: "R",
+      district_council_name: "Dist",
+      tangis_district_council_id: "D",
+      facility_name: "Unstocked HC",
+      tally_total_patients: "1",
+      tally_total_vials: "1",
+      submission_date: "",
+      report_full_date: "",
+      tally_report_month: "Old (1/2000)",
+    },
+  ];
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rows.mockResolvedValue(TWO_FAC as any);
+  });
+
+  it("off → 50% (1 of 2 facilities reported this month)", async () => {
+    const data = await getCompletenessData(null, null, null, false);
+    expect(data).toHaveLength(1);
+    expect(data[0].monthlyCompleteness[curKey]).toBe(50);
+  });
+
+  it("on → 100% (only the stocked facility counts, and it reported)", async () => {
+    stock.mockResolvedValue({ "f-stock": true, "f-nostock": null });
+    const data = await getCompletenessData(null, null, null, true);
+    expect(data).toHaveLength(1);
+    // Rolled up over the stocked facility only: 1 of 1 reported.
+    expect(data[0].monthlyCompleteness[curKey]).toBe(100);
+  });
+});

--- a/src/lib/data/api.test.ts
+++ b/src/lib/data/api.test.ts
@@ -1,14 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock the data layer so we control the rows without hitting /api/monthly-tz.
+// Mock the data layer so we control the rows without hitting /api/monthly-tz
+// or /api/health-facilities.
 vi.mock("$data/liveDB", () => ({
   fetchMonthlyData: vi.fn(),
+  fetchVaccineStock: vi.fn(),
 }));
 
 import { getCompletenessData, getFacilitiesByRegionDistrict } from "./api";
-import { fetchMonthlyData } from "$data/liveDB";
+import { fetchMonthlyData, fetchVaccineStock } from "$data/liveDB";
 
 const rows = vi.mocked(fetchMonthlyData);
+const stock = vi.mocked(fetchVaccineStock);
 
 // Two regions, one facility each.
 const ROWS = [
@@ -44,6 +47,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   rows.mockResolvedValue(ROWS as any);
+  // Default: stock service unavailable (filter-off tests never read this).
+  stock.mockResolvedValue(null);
 });
 
 // Regression: the detailed-data table previously showed every region. It must
@@ -84,5 +89,35 @@ describe("getCompletenessData — region whitelist", () => {
   it("includes nothing when the allowed list is empty", async () => {
     const data = await getCompletenessData(null, null, []);
     expect(data).toEqual([]);
+  });
+});
+
+describe("getCompletenessData — vaccine-stock filter", () => {
+  const regionNames = (data: { regionName: string | null }[]) =>
+    data.map((d) => d.regionName).sort();
+
+  it("keeps only facilities marked true; null/false/absent are excluded", async () => {
+    // f-mt has stock (true); f-mr is unknown (null).
+    stock.mockResolvedValue({ "f-mt": true, "f-mr": null });
+    const data = await getCompletenessData(null, null, null, true);
+    expect(regionNames(data)).toEqual(["Mtwara"]);
+  });
+
+  it("does not fetch the stock map when the filter is off", async () => {
+    const data = await getCompletenessData(null, null, null, false);
+    expect(stock).not.toHaveBeenCalled();
+    expect(regionNames(data)).toEqual(["Morogoro", "Mtwara"]);
+  });
+
+  it("fails open (shows all) when the stock service is unavailable (null)", async () => {
+    stock.mockResolvedValue(null);
+    const data = await getCompletenessData(null, null, null, true);
+    expect(regionNames(data)).toEqual(["Morogoro", "Mtwara"]);
+  });
+
+  it("shows nothing when the loaded map is empty (not a fail-open)", async () => {
+    stock.mockResolvedValue({});
+    const data = await getCompletenessData(null, null, null, true);
+    expect(regionNames(data)).toEqual([]);
   });
 });

--- a/src/lib/data/api.test.ts
+++ b/src/lib/data/api.test.ts
@@ -7,7 +7,11 @@ vi.mock("$data/liveDB", () => ({
   fetchVaccineStock: vi.fn(),
 }));
 
-import { getCompletenessData, getFacilitiesByRegionDistrict } from "./api";
+import {
+  getCompletenessData,
+  getFacilitiesByRegionDistrict,
+  type CompletenessData,
+} from "./api";
 import { fetchMonthlyData, fetchVaccineStock } from "$data/liveDB";
 
 const rows = vi.mocked(fetchMonthlyData);
@@ -178,5 +182,79 @@ describe("getCompletenessData — completeness recalculates with the filter", ()
     expect(data).toHaveLength(1);
     // Rolled up over the stocked facility only: 1 of 1 reported.
     expect(data[0].monthlyCompleteness[curKey]).toBe(100);
+  });
+});
+
+// Exhaustive accuracy: one region, two districts, mixed stock + mixed reporting.
+// Verifies exact %s at facility / district / region level in both modes.
+describe("getCompletenessData — multi-district accuracy", () => {
+  const now = new Date();
+  const cur = `Now (${now.getMonth() + 1}/${now.getFullYear()})`; // reported (in last 12)
+  const k = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const OLD = "Old (1/2000)"; // exists but never reported in the last 12 months
+
+  const mk = (fid: string, did: string, dname: string, month: string) => ({
+    tangis_facility_id: fid,
+    region_name: "Reg",
+    tangis_region_id: "R",
+    district_council_name: dname,
+    tangis_district_council_id: did,
+    facility_name: fid,
+    tally_total_patients: "1",
+    tally_total_vials: "1",
+    submission_date: "",
+    report_full_date: "",
+    tally_report_month: month,
+  });
+
+  // D1: f1(stock,reported) f2(stock,NOT reported) f3(no-stock,reported)
+  // D2: f4(no-stock,reported) f5(false-stock,reported)
+  const SCENARIO = [
+    mk("f1", "D1", "D1", cur),
+    mk("f2", "D1", "D1", OLD),
+    mk("f3", "D1", "D1", cur),
+    mk("f4", "D2", "D2", cur),
+    mk("f5", "D2", "D2", cur),
+  ];
+  const STOCK = {
+    f1: true,
+    f2: true,
+    f3: null,
+    f4: null,
+    f5: false,
+  } as Record<string, boolean | null>;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    rows.mockResolvedValue(SCENARIO as any);
+  });
+
+  const region = (data: CompletenessData[]) =>
+    data.find((r) => r.regionName === "Reg")!;
+  const district = (data: CompletenessData[], name: string) =>
+    region(data).children!.find((d) => d.districtName === name);
+  const facility = (data: CompletenessData[], dist: string, fid: string) =>
+    district(data, dist)!.children!.find((f) => f.facilityID === fid)!;
+
+  it("OFF: counts all 5 facilities — region 80%, D1 67%, D2 100%", async () => {
+    const data = await getCompletenessData(null, null, null, false);
+    expect(region(data).monthlyCompleteness[k]).toBe(80); // 4 of 5 reported
+    expect(district(data, "D1")!.monthlyCompleteness[k]).toBe(67); // 2 of 3
+    expect(district(data, "D2")!.monthlyCompleteness[k]).toBe(100); // 2 of 2
+    expect(district(data, "D1")!.children).toHaveLength(3);
+    expect(district(data, "D2")!.children).toHaveLength(2);
+    // Facility-level booleans (✓/✗)
+    expect(facility(data, "D1", "f1").monthlyCompleteness[k]).toBe(true);
+    expect(facility(data, "D1", "f2").monthlyCompleteness[k]).toBe(false);
+  });
+
+  it("ON: only stocked (true) facilities — region 50%, D1 50%, D2 gone", async () => {
+    stock.mockResolvedValue(STOCK);
+    const data = await getCompletenessData(null, null, null, true);
+    // Only f1, f2 survive (true). f3 null, f4 null, f5 false → excluded.
+    expect(district(data, "D1")!.children).toHaveLength(2);
+    expect(district(data, "D2")).toBeUndefined(); // whole district drops out
+    expect(district(data, "D1")!.monthlyCompleteness[k]).toBe(50); // 1 of 2 (f1 yes, f2 no)
+    expect(region(data).monthlyCompleteness[k]).toBe(50); // 1 of 2
   });
 });

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -381,6 +381,11 @@ export async function getCompletenessData(
   // tangis_facility_id). Off by default; only then is PMP queried.
   onlyWithVaccineStock: boolean = false,
 ): Promise<CompletenessData[]> {
+  // No allowed regions → nothing to show; skip the data and PMP fetches.
+  if (allowedRegionIDs !== null && allowedRegionIDs.length === 0) {
+    return [];
+  }
+
   const rows = await fetchMonthlyData();
 
   // null → unavailable (fail open); a map (even empty) → filter applies.

--- a/src/lib/data/api.ts
+++ b/src/lib/data/api.ts
@@ -1,5 +1,5 @@
 import { type MonthlyDataRow } from "$lib/stores/uiStore";
-import { fetchMonthlyData } from "$data/liveDB";
+import { fetchMonthlyData, fetchVaccineStock } from "$data/liveDB";
 // import { fetchMonthlyData as fetchMockData } from "$data/mockDB";
 
 // types
@@ -377,8 +377,16 @@ export async function getCompletenessData(
   //   - empty array     → the user can see no regions.
   //   - non-empty array → the user can see only those regions.
   allowedRegionIDs: string[] | null = null,
+  // Keep only facilities with has_vaccine_stock === true (joined by
+  // tangis_facility_id). Off by default; only then is PMP queried.
+  onlyWithVaccineStock: boolean = false,
 ): Promise<CompletenessData[]> {
   const rows = await fetchMonthlyData();
+
+  // null → unavailable (fail open); a map (even empty) → filter applies.
+  const stockByFacility = onlyWithVaccineStock
+    ? await fetchVaccineStock()
+    : null;
 
   // Generate last 12 months from current date (same logic as frontend)
   const now = new Date();
@@ -424,6 +432,13 @@ export async function getCompletenessData(
     if (
       allowedRegionSet !== null &&
       !allowedRegionSet.has(row.tangis_region_id)
+    ) {
+      return false;
+    }
+    // Vaccine-stock filter (true only; skipped when map is null/unavailable).
+    if (
+      stockByFacility !== null &&
+      stockByFacility[row.tangis_facility_id] !== true
     ) {
       return false;
     }

--- a/src/lib/data/liveDB.ts
+++ b/src/lib/data/liveDB.ts
@@ -43,3 +43,44 @@ export async function fetchMonthlyData(
     );
   }
 }
+
+// tangis_facility_id → has_vaccine_stock, from PMP via /api/health-facilities.
+type VaccineStockMap = Record<string, boolean | null>;
+
+let vaccineStockCache: { data: VaccineStockMap; timestamp: number } | null =
+  null;
+const VACCINE_STOCK_CACHE_DURATION = 60 * 60 * 1000; // 60 minutes
+
+// Loaded map (possibly empty) on success; null when unavailable (callers fail open).
+export async function fetchVaccineStock(
+  fetchFn?: typeof fetch,
+): Promise<VaccineStockMap | null> {
+  const now = Date.now();
+  if (
+    vaccineStockCache &&
+    now - vaccineStockCache.timestamp < VACCINE_STOCK_CACHE_DURATION
+  ) {
+    return vaccineStockCache.data;
+  }
+
+  try {
+    const _fetch = fetchFn || fetch;
+    const response = await _fetch("/api/health-facilities");
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const result = await response.json();
+
+    if (!result.success) {
+      throw new Error(result.error || "Failed to fetch vaccine stock");
+    }
+
+    vaccineStockCache = { data: result.data, timestamp: now }; // cache successes only
+    return result.data;
+  } catch (error) {
+    console.error("[API] Vaccine stock request error:", error);
+    return null; // unavailable → callers fail open
+  }
+}

--- a/src/lib/server/pmp.test.ts
+++ b/src/lib/server/pmp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isEmailWhitelisted } from "./pmp";
+import { isEmailWhitelisted, getVaccineStockByFacility } from "./pmp";
 
 // Regression test for the 2-minute whitelist cache. This is what bounds how
 // quickly a PMP revocation takes effect: the whitelist must be fetched once,
@@ -55,5 +55,75 @@ describe("isEmailWhitelisted — 2-minute cache", () => {
     vi.setSystemTime(TTL_MS + 1);
     await isEmailWhitelisted("a@b.com");
     expect(whitelistFetches()).toBe(2);
+  });
+});
+
+// Region scoping happens server-side (null/empty/list convention).
+describe("getVaccineStockByFacility — region scoping", () => {
+  // Three facilities across two PMP regions.
+  const FACILITIES = [
+    { id: "f-mt-1", region_id: "R-MT", has_vaccine_stock: true },
+    { id: "f-mt-2", region_id: "R-MT", has_vaccine_stock: null },
+    { id: "f-mr-1", region_id: "R-MR", has_vaccine_stock: true },
+  ];
+
+  beforeEach(() => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/security/login")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: "t", refresh_token: "r" }),
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => FACILITIES,
+      } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns every facility when allowedRegionIDs is null (unrestricted)", async () => {
+    const map = await getVaccineStockByFacility(undefined, null);
+    expect(map).not.toBeNull();
+    expect(Object.keys(map!).sort()).toEqual(["f-mr-1", "f-mt-1", "f-mt-2"]);
+  });
+
+  it("returns only facilities in the allowed regions", async () => {
+    const map = await getVaccineStockByFacility(undefined, ["R-MT"]);
+    expect(map).not.toBeNull();
+    expect(Object.keys(map!).sort()).toEqual(["f-mt-1", "f-mt-2"]);
+    // Tri-state preserved within the allowed region.
+    expect(map!["f-mt-1"]).toBe(true);
+    expect(map!["f-mt-2"]).toBe(null);
+  });
+
+  it("returns an empty map when the allowed list is empty (resolved, no regions)", async () => {
+    const map = await getVaccineStockByFacility(undefined, []);
+    expect(map).toEqual({});
+  });
+
+  it("returns null when PMP is unavailable (so callers fail open)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("/security/login")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ access_token: "t", refresh_token: "r" }),
+          } as unknown as Response;
+        }
+        return { ok: false, status: 500 } as unknown as Response; // PMP down
+      }),
+    );
+    const map = await getVaccineStockByFacility(undefined, null);
+    expect(map).toBeNull();
   });
 });

--- a/src/lib/server/pmp.ts
+++ b/src/lib/server/pmp.ts
@@ -18,6 +18,14 @@ interface PMPUserRegions {
   name: string;
 }
 
+interface PMPHealthFacility {
+  // id == tan-gis facility_id == Audrey's monthly_tz.tangis_facility_id.
+  id: string;
+  region_id: string;
+  // Tri-state: true = has stock, null = unknown (default), false = unused.
+  has_vaccine_stock: boolean | null;
+}
+
 class PMPClient {
   private accessToken: string | null = null;
   private refreshToken: string | null = null;
@@ -165,6 +173,43 @@ class PMPClient {
       throw error;
     }
   }
+
+  async getHealthFacilities(
+    fetchFn?: typeof fetch,
+  ): Promise<PMPHealthFacility[]> {
+    if (!this.accessToken) {
+      await this.authenticate();
+    }
+
+    try {
+      const _fetch = fetchFn || fetch;
+      const response = await _fetch(
+        `${this.baseUrl}/rabies_data_api/v1/health_facilities`,
+        {
+          headers: {
+            Authorization: `Bearer ${this.accessToken}`,
+          },
+        },
+      );
+
+      if (response.status === 401) {
+        // Token might be expired, try to refresh
+        await this.refreshAccessToken();
+        return this.getHealthFacilities(fetchFn);
+      }
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch health facilities: ${response.status}`,
+        );
+      }
+
+      return (await response.json()) as PMPHealthFacility[];
+    } catch (error) {
+      console.error("[PMP] Failed to fetch health facilities from PMP:", error);
+      throw error;
+    }
+  }
 }
 
 // Singleton instance
@@ -209,6 +254,36 @@ export async function isEmailWhitelisted(email: string): Promise<boolean> {
 
     // In production, deny access for security
     return false;
+  }
+}
+
+// tangis_facility_id → has_vaccine_stock, scoped to allowedRegionIDs (null =
+// all, [] = none, list = those). null on PMP failure (fail open); map otherwise.
+export async function getVaccineStockByFacility(
+  fetchFn?: typeof fetch,
+  allowedRegionIDs: string[] | null = null,
+): Promise<Record<string, boolean | null> | null> {
+  try {
+    const client = getPMPClient();
+    const facilities = await client.getHealthFacilities(fetchFn);
+
+    const allowedRegionSet =
+      allowedRegionIDs !== null ? new Set(allowedRegionIDs) : null;
+
+    const stockById: Record<string, boolean | null> = {};
+    for (const facility of facilities) {
+      if (
+        allowedRegionSet !== null &&
+        !allowedRegionSet.has(facility.region_id)
+      ) {
+        continue;
+      }
+      stockById[facility.id] = facility.has_vaccine_stock ?? null;
+    }
+    return stockById;
+  } catch (error) {
+    console.error("[PMP] Error fetching vaccine stock map:", error);
+    return null; // unavailable (≠ empty scope) → callers fail open
   }
 }
 

--- a/src/lib/server/pmp.ts
+++ b/src/lib/server/pmp.ts
@@ -243,16 +243,7 @@ export async function isEmailWhitelisted(email: string): Promise<boolean> {
     return isWhitelisted;
   } catch (error) {
     console.error("[PMP] Error checking email whitelist:", error);
-
-    // In case of PMP unavailability, or NNetlify previews with dynamic domains
-    // We want to allow access in development but deny in production.
-    // For security, we default to denying access.
-    if (import.meta.env.DEV) {
-      console.warn("[PMP] Development mode: PMP unavailable, allowing access");
-      return true;
-    }
-
-    // In production, deny access for security
+    // PMP unavailable → deny access (fail-closed, all environments).
     return false;
   }
 }
@@ -306,17 +297,7 @@ export async function getUserAllowedRegions(
     return result;
   } catch (error) {
     console.error("[PMP] Error fetching user regions:", error);
-
-    // In development mode, return all available regions
-    if (import.meta.env.DEV) {
-      console.warn(
-        "[PMP] Development mode: PMP unavailable, returning all regions",
-      );
-      // This would need to be imported from api.ts, but for now return empty array
-      return [];
-    }
-
-    // In production, return empty array for security
+    // PMP unavailable → no regions (fail-closed).
     return [];
   }
 }

--- a/src/routes/api/health-facilities/+server.ts
+++ b/src/routes/api/health-facilities/+server.ts
@@ -1,0 +1,61 @@
+import { json, type RequestHandler } from "@sveltejs/kit";
+import {
+  getUserAllowedRegions,
+  getVaccineStockByFacility,
+} from "$lib/server/pmp";
+
+// { tangis_facility_id: has_vaccine_stock } from PMP, region-scoped, server-side
+// (PMP creds and out-of-region data never reach the browser).
+export const GET: RequestHandler = async ({ locals, fetch }) => {
+  try {
+    const session = await locals.auth();
+    if (!session?.user?.email) {
+      return json(
+        { success: false, error: "Unauthorized", data: {} },
+        { status: 401 },
+      );
+    }
+
+    // Resolve the caller's regions directly (session-derived, not spoofable).
+    // DEV-empty = unrestricted (mirrors /api/user-regions); prod-empty stays
+    // fail-closed (no regions → no facilities).
+    const allowedRegions = await getUserAllowedRegions(
+      session.user.email,
+      fetch,
+    );
+    const allowedRegionIDs = allowedRegions.map((r) => r.id);
+    const regionFilter =
+      import.meta.env.DEV && allowedRegionIDs.length === 0
+        ? null
+        : allowedRegionIDs;
+
+    const stockByFacility = await getVaccineStockByFacility(
+      fetch,
+      regionFilter,
+    );
+    if (stockByFacility === null) {
+      // PMP unavailable → signal failure so the client fails open.
+      return json(
+        { success: false, error: "Vaccine stock unavailable", data: {} },
+        { status: 502 },
+      );
+    }
+
+    return json({
+      success: true,
+      data: stockByFacility,
+      count: Object.keys(stockByFacility).length,
+    });
+  } catch (error) {
+    console.error("Failed to fetch vaccine stock from PMP:", error);
+
+    return json(
+      {
+        success: false,
+        error: `Failed to fetch vaccine stock: ${error instanceof Error ? error.message : "Unknown error"}`,
+        data: {},
+      },
+      { status: 500 },
+    );
+  }
+};


### PR DESCRIPTION
Closes https://github.com/RabiesResearch/project_IBCM/issues/255
Requires https://github.com/RabiesResearch/project-management-portal/pull/32 to be merged

## What
Adds a **"Only show facilities with vaccine stock"** toggle (default on) to the completeness table, backed by PMP's `has_vaccine_stock` flag. Implements the Audrey side of #255.

Before:
<img width="1722" height="510" alt="Screenshot from 2026-06-19 18-46-10" src="https://github.com/user-attachments/assets/75236fca-e085-4bef-af44-725086d0bd5d" />

After:
<img width="1722" height="510" alt="Screenshot from 2026-06-19 18-35-13" src="https://github.com/user-attachments/assets/69f7a74e-7413-482e-8a77-bd1b9712d1cc" />


## How
- **New `/api/health-facilities` endpoint** — returns `{ tangis_facility_id → has_vaccine_stock }` from PMP, **scoped server-side to the caller's allowed regions**, so PMP credentials and out-of-region data never reach the browser.
- **`pmp.ts`** — `getHealthFacilities()` + `getVaccineStockByFacility()` (region-scoped; returns `null` on PMP failure so callers fail open — distinct from a genuinely empty scope).
- **`getCompletenessData`** — joins the flag by `tangis_facility_id` (== PMP `health_facility.id`, the shared tan-gis id — no name-matching) and keeps only facilities marked `true`.
- **Browser** — `fetchVaccineStock` (the toggle defaults on and reloads on change).

### Why the 60-min client cache (`liveDB.ts`)
The table re-runs `getCompletenessData` on every region/district selection and every toggle flip, so the stock map would otherwise be re-fetched repeatedly. Since each fetch is a PMP-backed round-trip and the stock flags change rarely, the map is cached in the browser for 60 minutes (mirrors the existing `monthlyDataCache`). Only the first call in the window hits the network; failures are not cached (so they retry). Trade-off: a newly-flagged facility can take up to 60 min (or a page reload) to appear — acceptable for this data.

## Behaviour note — completeness recalculates with the toggle
The displayed completeness **changes when the checkbox is on vs off**. Because facilities are filtered out *before* the district/region totals are computed, the **percentages and "X of Y reported" rollups recalculate over the filtered set**:
- **Checked (on):** region/district completeness reflects **only facilities with vaccine stock** (`has_vaccine_stock === true`).
- **Unchecked (off):** completeness reflects **all** facilities (current behaviour).

So a region's % can differ between the two states — this is intended, not a bug. Covered by unit tests (e.g. a district reads 50% off / 100% on; a multi-district case reads region 80% off / 50% on).

## Also (2nd commit) — fail closed when PMP is unavailable
`refactor: fail closed when PMP is unavailable` removes a **dev-only bypass** where Audrey allowed access (and returned all regions) when PMP was unreachable. PMP-down now **fails closed in every environment** (matching prod).

**Why this is safe / in scope:**
- The bypass is **pre-existing** — it was introduced in #65 ("Add Google OAuth whitelist with PMP integration"), not by this feature. This PR only *removes* it.
- It's a **security improvement**: dev no longer grants dashboard access when the whitelist can't be verified. The branch was `import.meta.env.DEV`-gated, so production behaviour is unchanged (it already failed closed there).
- Verified live: with PMP stopped, the dashboard now correctly returns **403** in dev.
- The separate, legitimate **"whitelisted user with no regions = all regions"** semantic is left **unchanged**.

## Notes
- `has_vaccine_stock` is treated as tri-state (`true` / `null`=unknown / `false` reserved for a future "no"); the filter keeps only `true`, so it's forward-compatible.
- Needs PMP PR #32 (the `has_vaccine_stock` field) live for real data.

## Follow-ups (pre-existing, out of scope — tracked under #252)
- #262 — `/api/monthly-tz` serves all regions (region filtering is client-side only).
- #263 — PMP client retries on 401 unbounded (`getWhitelist`/`getUserRegions`/`getHealthFacilities`); bound to a single refresh+retry.

## Tests
`svelte-check` clean · `eslint` clean · 37 unit tests (filter behaviour, server-side region scoping, and completeness-accuracy in both toggle states).